### PR TITLE
remove unnecessary loading of esprima

### DIFF
--- a/benchmark/asts.js
+++ b/benchmark/asts.js
@@ -1,6 +1,5 @@
 var fs = require('fs'),
-    path = require('path'),
-    esprima = require('esprima');
+    path = require('path');
 
 var FILES_PATH = path.join(__dirname, './asts');
 


### PR DESCRIPTION
esprima is not used in the file, and with the `require('esprima')` call present the benchmarking script fails (since esprima is not listed in `benchmark/package.json`)
