### PR TITLE
fix access to global object when loading esotope.js directly in browser

### DIFF
--- a/esotope.js
+++ b/esotope.js
@@ -32,7 +32,7 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-(function () {
+(function (global) {
 
     'use strict';
 
@@ -2292,7 +2292,7 @@
 
     else {
         esotope.browser = true;
-        this.esotope = esotope;
+        global.esotope = esotope;
     }
 
-})();
+})(this);


### PR DESCRIPTION
In strict mode, `this` does not reference the global object when the caller doesn't pass it in
